### PR TITLE
🔒 Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/check_fmt.yml
+++ b/.github/workflows/check_fmt.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check formatting
-        uses: omnilib/ufmt@action-v1
+        uses: omnilib/ufmt@aa3e972414baa6660e4140344718492d510bf47a  # action-v1
         with:
           path: sam2 tools
           version: "2.0.0b2"


### PR DESCRIPTION
## 🔒 Pin GitHub Actions to commit SHAs

This PR pins all GitHub Actions to their exact commit SHA instead of mutable tags or branch names.

**Why?**
Pinning to a SHA prevents supply chain attacks where a tag (e.g. `v4`) could be moved to point to malicious code.

### Changes

| Workflow | Action | Avant | Après | SHA |
|---|---|---|---|---|
| `check_fmt.yml` | `omnilib/ufmt` | `action-v1` | `action-v1` | `aa3e972414ba…` |

> 🤖 Generated by `/github-actions-audit` — [security/pin-actions-to-sha]


Closes huggingface/tracking-issues#253